### PR TITLE
Fail fast when API key is not provided

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -188,6 +188,16 @@ runs:
           echo "ClaudeCode only runs on pull requests, skipping"
           exit 0
         fi
+        
+        # Validate API key is provided
+        if [ -z "$ANTHROPIC_API_KEY" ]; then
+          echo "::error::ANTHROPIC_API_KEY is not set. Please provide the claude-api-key input to the action."
+          echo "Example usage:"
+          echo "  - uses: anthropics/claude-code-security-reviewer@main"
+          echo "    with:"
+          echo "      claude-api-key: \${{ secrets.ANTHROPIC_API_KEY }}"
+          exit 1
+        fi
                 
         # Set timeout
         export CLAUDE_TIMEOUT="${{ inputs.claudecode-timeout }}"


### PR DESCRIPTION
## Summary
- Add early validation for the ANTHROPIC_API_KEY in the GitHub Action
- Fail with a clear error message if the API key is missing or empty
- Provides helpful usage example in the error message

## Changes
- Added API key validation check immediately after PR validation in the bash script
- Shows clear error with example usage when API key is missing

## Test plan
- Run the action without providing the claude-api-key input
- Verify it fails early with a clear error message
- Run with a valid API key and verify normal operation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>