### PR TITLE
Add security considerations for prompt injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ jobs:
           claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
 ```
 
+## Security Considerations
+
+This action is not hardened against prompt injection attacks and should only be used to review trusted PRs. We recommend [configuring your repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories) to use the "Require approval for all external contributors" option to ensure workflows only run after a maintainer has reviewed the PR.
+
 ## Configuration Options
 
 ### Action Inputs

--- a/claudecode/github_action_audit.py
+++ b/claudecode/github_action_audit.py
@@ -224,7 +224,8 @@ class SimpleClaudeRunner:
             cmd = [
                 'claude',
                 '--output-format', 'json',
-                '--model', DEFAULT_CLAUDE_MODEL
+                '--model', DEFAULT_CLAUDE_MODEL,
+                '--disallowed-tools', 'Bash(ps:*)'
             ]
             
             # Run Claude Code with retry logic

--- a/claudecode/test_claude_runner.py
+++ b/claudecode/test_claude_runner.py
@@ -166,7 +166,8 @@ class TestSimpleClaudeRunner:
         assert call_args[0][0] == [
             'claude',
             '--output-format', 'json',
-            '--model', DEFAULT_CLAUDE_MODEL
+            '--model', DEFAULT_CLAUDE_MODEL,
+            '--disallowed-tools', 'Bash(ps:*)'
         ]
         assert call_args[1]['input'] == 'test prompt'
         assert call_args[1]['cwd'] == Path('/tmp/test')


### PR DESCRIPTION
Also, add `ps` as an explicitly disallowed tool. 