### PR TITLE
Pin versions in workflow files

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -14,9 +14,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: ./  # Points directly to action.yml
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 pinned to commit hash
+
+      - uses: ./ # Points directly to action.yml
         with:
           comment-pr: true
           upload-results: true

--- a/.github/workflows/test-claudecode.yml
+++ b/.github/workflows/test-claudecode.yml
@@ -16,45 +16,45 @@ permissions:
 jobs:
   test-claudecode:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    
-    - name: Install Claude CLI
-      run: |
-        npm install -g @anthropic-ai/claude-code
-    
-    - name: Install dependencies
-      run: |
-        pip install pytest pytest-cov
-        pip install -r claudecode/requirements.txt
-    
-    - name: Run ClaudeCode unit tests
-      run: |
-        export PYTHONPATH="${PYTHONPATH}:${PWD}"
-        pytest claudecode -v --cov=claudecode --cov-report=term-missing
-    
-    - name: Install Bun
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-    
-    - name: Install script dependencies
-      run: |
-        cd scripts
-        bun install
-    
-    - name: Run comment script tests
-      run: |
-        cd scripts
-        bun test
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 pinned to commit hash
+
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1 pinned to commit hash
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 pinned to commit hash
+        with:
+          node-version: "20"
+
+      - name: Install Claude CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Install dependencies
+        run: |
+          pip install pytest pytest-cov
+          pip install -r claudecode/requirements.txt
+
+      - name: Run ClaudeCode unit tests
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          pytest claudecode -v --cov=claudecode --cov-report=term-missing
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0 pinned to commit hash
+        with:
+          bun-version: latest
+
+      - name: Install script dependencies
+        run: |
+          cd scripts
+          bun install
+
+      - name: Run comment script tests
+        run: |
+          cd scripts
+          bun test

--- a/action.yml
+++ b/action.yml
@@ -69,14 +69,14 @@ runs:
         echo "::endgroup::"
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0 pinned to commit hash
       with:
         python-version: '3.x'
     
     - name: Check ClaudeCode run history
       id: claudecode-history
       if: github.event_name == 'pull_request'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 pinned to commit hash
       with:
         path: .claudecode-marker
         key: claudecode-${{ github.repository_id }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
@@ -149,14 +149,14 @@ runs:
     
     - name: Save ClaudeCode reservation to cache
       if: steps.claudecode-check.outputs.enable_claudecode == 'true' && github.event_name == 'pull_request'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 pinned to commit hash
       with:
         path: .claudecode-marker
         key: claudecode-${{ github.repository_id }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
     
     - name: Set up Node.js
       if: steps.claudecode-check.outputs.enable_claudecode == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 pinned to commit hash
       with:
         node-version: '18'
     
@@ -307,7 +307,7 @@ runs:
     
     - name: Upload scan results
       if: always() && inputs.upload-results == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 pinned to commit hash
       with:
         name: security-review-results
         path: |


### PR DESCRIPTION
Instead of using `@version`, pin all github actions uses to a specific commit hash. This makes is that much harder for a supply chain attack to occur.

Related files taken from the latest github action run

`sast.yml`

https://github.com/anthropics/claude-code-security-review/actions/runs/19684201145/job/56385581072

<img width="1248" height="812" alt="Screenshot 2026-01-12 at 12 29 39 PM" src="https://github.com/user-attachments/assets/22e7a00e-bd8f-4178-9bba-5b49db71deb5" />

`test-claudecode.yml`

https://github.com/anthropics/claude-code-security-review/actions/runs/19684201170/job/56385581033

<img width="2030" height="1164" alt="Screenshot 2026-01-12 at 12 31 22 PM" src="https://github.com/user-attachments/assets/f4ecaa56-7da4-47ec-8252-fd45f446bb9b" />

The only difference is the  `oven-sh/setup-bun`, which in the latest run was set as [v2](https://github.com/oven-sh/setup-bun/releases/tag/v2). I don't mind pinning it to that version if needed.