### PR TITLE
Rewrite for generalized code review

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -96,7 +96,7 @@ No issues found. Checked for bugs and CLAUDE.md compliance.
 
 ---
 
-- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-code/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/PSPDFKit-labs/claude-code-review/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
   - Requires full git sha
   - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
   - Repo name must match the repo you're code reviewing

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -97,7 +97,7 @@ No security issues found. Checked for security vulnerabilities and CLAUDE.md sec
 
 ---
 
-- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-code/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/PSPDFKit-labs/claude-code-review/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
   - Requires full git sha
   - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
   - Repo name must match the repo you're code reviewing

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This action is not hardened against prompt injection attacks and should only be 
 | `comment-pr` | Whether to comment on PRs with findings | `true` | No |
 | `upload-results` | Whether to upload results as artifacts | `true` | No |
 | `exclude-directories` | Comma-separated list of directories to exclude from scanning | None | No |
-| `claude-model` | Claude [model name](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names) to use. Defaults to Opus 4.1. | `claude-opus-4-1-20250805` | No |
+| `claude-model` | Claude [model name](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names) to use. Defaults to Opus 4.5. | `claude-opus-4-5-20251101` | No |
 | `claudecode-timeout` | Timeout for ClaudeCode analysis in minutes | `20` | No |
 | `run-every-commit` | Run ClaudeCode on every commit (skips cache check). Warning: May increase false positives on PRs with many commits. | `false` | No |
 | `false-positive-filtering-instructions` | Path to custom false positive filtering instructions text file | None | No |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Reviewer
 
-An AI-powered code review GitHub Action using Claude to analyze code changes for correctness, reliability, performance, maintainability, testing, and security, plus a dedicated security review pass. This action provides intelligent, context-aware review for pull requests using Anthropic's Claude Code tool for deep semantic analysis.
+An AI-powered code review GitHub Action using Claude to analyze code changes. Runs two focused passes: a code quality review (correctness, reliability, performance, maintainability, testing) and a dedicated security review. This action provides intelligent, context-aware review for pull requests using Anthropic's Claude Code tool for deep semantic analysis.
 
 Based on the original work from [anthropics/claude-code-security-review](https://github.com/anthropics/claude-code-security-review).
 
@@ -12,7 +12,7 @@ Based on the original work from [anthropics/claude-code-security-review](https:/
 - **Contextual Understanding**: Goes beyond pattern matching to understand code semantics and intent
 - **Language Agnostic**: Works with any programming language
 - **False Positive Filtering**: Advanced filtering to reduce noise and focus on real issues
-- **Dual-Pass Security**: Runs a general review and a dedicated security review by default
+- **Dual-Pass Review**: Runs focused code quality and security passes separately for better signal
 
 ## Quick Start
 
@@ -63,7 +63,7 @@ This action is not hardened against prompt injection attacks and should only be 
 | `false-positive-filtering-instructions` | Path to custom false positive filtering instructions text file | None | No |
 | `custom-review-instructions` | Path to custom code review instructions text file to append to the audit prompt | None | No |
 | `custom-security-scan-instructions` | Path to custom security scan instructions text file to append to the security section | None | No |
-| `run-general-review` | Whether to run the general code review pass | `true` | No |
+| `run-general-review` | Whether to run the code quality review pass (correctness, reliability, performance, maintainability, testing) | `true` | No |
 | `run-security-review` | Whether to run the dedicated security review pass | `true` | No |
 
 ### Action Outputs

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-# SAST package
+# Code review package

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Claude Code Reviewer'
-description: 'AI-powered code review GitHub Action using Claude to analyze code changes for correctness, reliability, performance, maintainability, testing, and security, plus a dedicated security pass'
+description: 'AI-powered code review GitHub Action using Claude. Runs two focused passes: code quality (correctness, reliability, performance, maintainability, testing) and security.'
 author: 'Nutrient'
 
 inputs:
@@ -54,7 +54,7 @@ inputs:
     default: ''
 
   run-general-review:
-    description: 'Whether to run the general code review pass (correctness, reliability, performance, maintainability, testing, and security)'
+    description: 'Whether to run the code quality review pass (correctness, reliability, performance, maintainability, testing)'
     required: false
     default: 'true'
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Claude Code Security Reviewer'
-description: 'AI-powered security review GitHub Action using Claude to analyze code changes for security vulnerabilities'
-author: 'Anthropic'
+name: 'Claude Code Reviewer'
+description: 'AI-powered code review GitHub Action using Claude to analyze code changes for correctness, reliability, performance, maintainability, testing, and security, plus a dedicated security pass'
+author: 'Nutrient'
 
 inputs:
   comment-pr:
@@ -24,12 +24,12 @@ inputs:
     default: '20'
   
   claude-api-key:
-    description: 'Anthropic Claude API key for security analysis'
+    description: 'Anthropic Claude API key for code review analysis'
     required: true
     default: ''
 
   claude-model:
-    description: 'Claude model to use for security analysis (e.g., claude-sonnet-4-20250514)'
+    description: 'Claude model to use for code review analysis (e.g., claude-sonnet-4-20250514)'
     required: false
     default: ''
 
@@ -43,14 +43,29 @@ inputs:
     required: false
     default: ''
 
-  custom-security-scan-instructions:
-    description: 'Path to custom security scan instructions text file to append to audit prompt'
+  custom-review-instructions:
+    description: 'Path to custom code review instructions text file to append to the audit prompt'
     required: false
     default: ''
 
+  custom-security-scan-instructions:
+    description: 'Path to custom security scan instructions text file to append to the security section (optional)'
+    required: false
+    default: ''
+
+  run-general-review:
+    description: 'Whether to run the general code review pass (correctness, reliability, performance, maintainability, testing, and security)'
+    required: false
+    default: 'true'
+
+  run-security-review:
+    description: 'Whether to run the dedicated security review pass'
+    required: false
+    default: 'true'
+
 outputs:
   findings-count:
-    description: 'Number of security findings'
+    description: 'Number of code review findings'
     value: ${{ steps.claudecode-scan.outputs.findings_count }}
   
   results-file:
@@ -185,12 +200,15 @@ runs:
         ENABLE_CLAUDE_FILTERING: 'true' 
         EXCLUDE_DIRECTORIES: ${{ inputs.exclude-directories }}
         FALSE_POSITIVE_FILTERING_INSTRUCTIONS: ${{ inputs.false-positive-filtering-instructions }}
+        CUSTOM_REVIEW_INSTRUCTIONS: ${{ inputs.custom-review-instructions }}
         CUSTOM_SECURITY_SCAN_INSTRUCTIONS: ${{ inputs.custom-security-scan-instructions }}
+        RUN_GENERAL_REVIEW: ${{ inputs.run-general-review }}
+        RUN_SECURITY_REVIEW: ${{ inputs.run-security-review }}
         CLAUDE_MODEL: ${{ inputs.claude-model }}
         CLAUDECODE_TIMEOUT: ${{ inputs.claudecode-timeout }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
-        echo "Running ClaudeCode AI security analysis..."
+        echo "Running ClaudeCode AI code review analysis..."
         echo "----------------------------------------"
         
         # Initialize outputs
@@ -207,7 +225,7 @@ runs:
         if [ -z "$ANTHROPIC_API_KEY" ]; then
           echo "::error::ANTHROPIC_API_KEY is not set. Please provide the claude-api-key input to the action."
           echo "Example usage:"
-          echo "  - uses: anthropics/claude-code-security-reviewer@main"
+          echo "  - uses: PSPDFKit-labs/claude-code-review@main"
           echo "    with:"
           echo "      claude-api-key: \$\{{ secrets.ANTHROPIC_API_KEY }}"
           exit 1
@@ -275,7 +293,7 @@ runs:
               CLAUDECODE_FINDINGS_COUNT=$(jq -r '.findings | if . == null then 0 else length end' claudecode/claudecode-results.json 2>/dev/null || echo "0")
               echo "::debug::Extracted ClaudeCode findings count: $CLAUDECODE_FINDINGS_COUNT"
               echo "findings_count=$CLAUDECODE_FINDINGS_COUNT" >> $GITHUB_OUTPUT
-              echo "ClaudeCode found $CLAUDECODE_FINDINGS_COUNT security issues"
+              echo "ClaudeCode found $CLAUDECODE_FINDINGS_COUNT review issues"
               
               # Also create findings.json for PR comment script
               jq '.findings // []' claudecode/claudecode-results.json > findings.json || echo '[]' > findings.json
@@ -309,7 +327,7 @@ runs:
       if: always() && inputs.upload-results == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: security-review-results
+        name: code-review-results
         path: |
           findings.json
           claudecode-results.json

--- a/claudecode/__init__.py
+++ b/claudecode/__init__.py
@@ -1,12 +1,12 @@
 """
-ClaudeCode - AI-Powered PR Security Audit Tool
+ClaudeCode - AI-Powered PR Code Review Tool
 
-A standalone security audit tool that uses Claude Code for comprehensive
-security analysis of GitHub pull requests.
+A standalone review tool that uses Claude Code for comprehensive
+analysis of GitHub pull requests.
 """
 
 __version__ = "1.0.0"
-__author__ = "Anthropic Security Team"
+__author__ = "Anthropic"
 
 # Import main components for easier access
 from claudecode.github_action_audit import (

--- a/claudecode/claude_api_client.py
+++ b/claudecode/claude_api_client.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 
 
 class ClaudeAPIClient:
-    """Client for calling Claude API directly for security analysis tasks."""
+    """Client for calling Claude API directly for review analysis tasks."""
     
     def __init__(self, 
                  model: Optional[str] = None,
@@ -146,10 +146,10 @@ class ClaudeAPIClient:
                               finding: Dict[str, Any], 
                               pr_context: Optional[Dict[str, Any]] = None,
                               custom_filtering_instructions: Optional[str] = None) -> Tuple[bool, Dict[str, Any], str]:
-        """Analyze a single security finding to filter false positives using Claude API.
+        """Analyze a single review finding to filter false positives using Claude API.
         
         Args:
-            finding: Single security finding to analyze
+            finding: Single review finding to analyze
             pr_context: Optional PR context for better analysis
             
         Returns:
@@ -180,15 +180,15 @@ class ClaudeAPIClient:
                 return False, {}, "Failed to parse JSON response"
                 
         except Exception as e:
-            logger.exception(f"Error during single finding security analysis: {str(e)}")
-            return False, {}, f"Single finding security analysis failed: {str(e)}"
+            logger.exception(f"Error during single finding review analysis: {str(e)}")
+            return False, {}, f"Single finding review analysis failed: {str(e)}"
 
     
     def _generate_system_prompt(self) -> str:
-        """Generate system prompt for security analysis."""
-        return """You are a security expert reviewing findings from an automated code audit tool.
-Your task is to filter out false positives and low-signal findings to reduce alert fatigue.
-You must maintain high recall (don't miss real vulnerabilities) while improving precision.
+        """Generate system prompt for review analysis."""
+        return """You are a senior code reviewer evaluating findings from an automated review tool.
+Your task is to filter out false positives and low-signal findings to reduce noise.
+You must maintain high recall (don't miss real issues) while improving precision.
 
 Respond ONLY with valid JSON in the exact format specified in the user prompt.
 Do not include explanatory text, markdown formatting, or code blocks."""
@@ -197,10 +197,10 @@ Do not include explanatory text, markdown formatting, or code blocks."""
                                        finding: Dict[str, Any], 
                                        pr_context: Optional[Dict[str, Any]] = None,
                                        custom_filtering_instructions: Optional[str] = None) -> str:
-        """Generate prompt for analyzing a single security finding.
+        """Generate prompt for analyzing a single review finding.
         
         Args:
-            finding: Single security finding
+            finding: Single review finding
             pr_context: Optional PR context
             
         Returns:
@@ -241,49 +241,28 @@ File Content ({file_path}): Error reading file - {error}
             filtering_section = custom_filtering_instructions
         else:
             filtering_section = """HARD EXCLUSIONS - Automatically exclude findings matching these patterns:
-1. Denial of Service (DOS) vulnerabilities or resource exhaustion attacks
-2. Secrets/credentials stored on disk (these are managed separately) 
-3. Rate limiting concerns or service overload scenarios (services don't need to implement rate limiting)
-4. Memory consumption or CPU exhaustion issues
-5. Lack of input validation on non-security-critical fields without proven security impact
-6. Input sanitization concerns for github action workflows
-7. A lack of hardening measures. Code is not expected to implement all security best practices, just avoid obvious vulnerabilities.
-8. Race conditions or timing attacks that are theoretical rather than practical issues. Only report a race condition if it is extremely problematic.
-9. Vulnerabilities related to outdated third-party libraries. These are managed separately and should not be reported here.
-10. Memory safety issues such as buffer overflows or use-after-free-vulnerabilities are impossible in rust. Do not report memory safety issues in rust code.
-11. Files that are only unit tests or only used as part of running tests.
-12. Log spoofing concerns. Outputing un-sanitized user input to logs is not a vulnerability.
-13. SSRF vulnerabilities that only control the path. SSRF is only a concern if it can control the host or protocol.
-14. Including user-controlled content in AI system prompts is not a vulnerability. In general, the inclusion of user input in an AI prompt is not a vulnerability.
-15. Do not report issues related to adding a dependency to a project that is not available from the relevant package repository. Depending on internal libraries that are not publicly available is not a vulnerability.
-16. Do not report issues that cause the code to crash, but are not actually a vulnerability. E.g. a variable that is undefined or null is not a vulnerability.
+1. Purely stylistic or formatting preferences (naming, spacing, comment wording) with no functional impact.
+2. Documentation-only issues or typos that do not affect behavior or safety.
+3. Refactor suggestions without a concrete bug, regression, or risk reduction.
+4. Hypothetical issues without a clear failure mode or reproducible impact.
+
+SECURITY-SPECIFIC EXCLUSIONS (apply ONLY if the category indicates security):
+1. Denial of Service (DOS) or resource exhaustion concerns without concrete exploitability.
+2. Rate limiting recommendations without a specific abuse path.
+3. Memory safety issues in memory-safe languages (e.g., Rust).
 
 SIGNAL QUALITY CRITERIA - For remaining findings, assess:
-1. Is there a concrete, exploitable vulnerability with a clear attack path?
-2. Does this represent a real security risk vs theoretical best practice?
+1. Is there a concrete failure mode or exploit path?
+2. Is the impact meaningful (bug, regression, security risk, data loss)?
 3. Are there specific code locations and reproduction steps?
-4. Would this finding be actionable for a security team?
+4. Would this be actionable for the team?
 
-PRECEDENTS - 
-1. Logging high value secrets in plaintext is a vulnerability. Otherwise, do not report issues around theoretical exposures of secrets. Logging URLs is assumed to be safe. Logging request headers is assumed to be dangerous since they likely contain credentials.
-2. UUIDs can be assumed to be unguessable and do not need to be validated. If a vulnerabilities requires guessing a UUID, it is not a valid vulnerability.
-3. Audit logs are not a critical security feature and should not be reported as a vulnerability if they are missing or modified.
-4. Environment variables and CLI flags are trusted values. Attackers are not able to modify them in a secure environment. Any attack that relies on controlling an environment variable is invalid.
-5. Resource management issues such as memory or file descriptor leaks are not valid.
-6. Subtle or low impact web vulnerabilities such as tabnabbing, XS-Leaks, prototype pollution, and open redirects are not valid.
-7. Vulnerabilities related to outdated third-party libraries. These are managed separately and should not be reported here.
-8. React is generally secure against XSS. React does not need to sanitize or escape user input unless it is using dangerouslySetInnerHTML or similar methods. Do not report XSS vulnerabilities in React components or tsx files unless they are using unsafe methods.
-9. Most vulnerabilities in github action workflows are not exploitable in practice. Before validating a github action workflow vulnerability ensure it is concrete and has a very specific attack path.
-10. A lack of permission checking or authentication in client-side TS code is not a vulnerability. Client-side code is not trusted and does not need to implement these checks, they are handled on the server-side. The same applies to all flows that send untrusted data to the backend, the backend is responsible for validating and sanitizing all inputs.
-11. Only include MEDIUM findings if they are obvious and concrete issues.
-12. Most vulnerabilities in ipython notebooks (*.ipynb files) are not exploitable in practice. Before validating a notebook vulnerability ensure it is concrete and has a very specific attack path.
-13. Logging non-PII data is not a vulnerability even if the data may be sensitive. Only report logging vulnerabilities if they expose sensitive information such as secrets, passwords, or personally identifiable information (PII).
-14. Command injection vulnerabilities in shell scripts are generally not exploitable in practice since shell scripts generally do not run with untrusted user input. Only report command injection vulnerabilities in shell scripts if they are concrete and have a very specific attack path for untrusted input.
-15. SSRF (Server-Side Request Forgery) vulnerabilities in client-side JavaScript/TypeScript files (.js, .ts, .tsx, .jsx) are not valid since client-side code cannot make server-side requests that would bypass firewalls or access internal resources. Only report SSRF in server-side code (e.g. Python or JS that is known to run on the server-side). The same logic applies to path-traversal attacks, they are not a problem in client-side JS.
-16. Path traversal attacks using ../ are generally not a problem when triggering HTTP requests. These are generally only relevant when reading files where the ../ may allow accessing unintended files.
-17. Injecting into log queries is generally not an issue. Only report this if the injection will definitely lead to exposing sensitive data to external users."""
+PRECEDENTS -
+1. Keep findings that indicate a likely production issue, security vulnerability, or significant regression.
+2. Only include MEDIUM findings if they are obvious and concrete issues.
+3. For security findings, prefer concrete exploitability and avoid theoretical best-practice gaps."""
         
-        return f"""I need you to analyze a security finding from an automated code audit and determine if it's a false positive.
+        return f"""I need you to analyze a code review finding from an automated audit and determine if it's a false positive.
 
 {pr_info}
 
@@ -292,7 +271,7 @@ PRECEDENTS -
 Assign a confidence score from 1-10:
 - 1-3: Low confidence, likely false positive or noise
 - 4-6: Medium confidence, needs investigation  
-- 7-10: High confidence, likely true vulnerability
+- 7-10: High confidence, likely true issue
 
 Finding to analyze:
 ```json
@@ -306,7 +285,7 @@ Respond with EXACTLY this JSON structure (no markdown, no code blocks):
   "confidence_score": 8,
   "keep_finding": true,
   "exclusion_reason": null,
-  "justification": "Clear SQL injection vulnerability with specific exploit path"
+  "justification": "Clear off-by-one error that causes data loss on edge cases"
 }}"""
 
     
@@ -372,5 +351,3 @@ def get_claude_api_client(model: str = DEFAULT_CLAUDE_MODEL,
         api_key=api_key,
         timeout_seconds=timeout_seconds
     )
-
-

--- a/claudecode/constants.py
+++ b/claudecode/constants.py
@@ -5,7 +5,7 @@ Constants and configuration values for ClaudeCode.
 import os
 
 # API Configuration
-DEFAULT_CLAUDE_MODEL = os.environ.get('CLAUDE_MODEL') or 'claude-opus-4-1-20250805'
+DEFAULT_CLAUDE_MODEL = os.environ.get('CLAUDE_MODEL') or 'claude-opus-4-5-20251101'
 DEFAULT_TIMEOUT_SECONDS = 180  # 3 minutes
 DEFAULT_MAX_RETRIES = 3
 RATE_LIMIT_BACKOFF_MAX = 30  # Maximum backoff time for rate limits

--- a/claudecode/evals/README.md
+++ b/claudecode/evals/README.md
@@ -1,13 +1,13 @@
-# SAST Evaluation Tool
+# Code Review Evaluation Tool
 
-This directory contains a tool for evaluating the SAST (Static Application Security Testing) tool on individual GitHub pull requests.
+This directory contains a tool for evaluating the Claude Code Reviewer on individual GitHub pull requests.
 
 ## Overview
 
-The evaluation tool allows you to run the Claude Code Security Reviewer on any GitHub PR to analyze its security findings. This is useful for:
+The evaluation tool allows you to run the Claude Code Reviewer on any GitHub PR to analyze its findings. This is useful for:
 - Testing the tool on specific PRs
 - Evaluating performance and accuracy
-- Debugging security analysis issues
+- Debugging review analysis issues
 
 ## Requirements
 
@@ -38,7 +38,7 @@ python -m claudecode.evals.run_eval example/repo#123 --verbose
 The evaluation generates a JSON file in the output directory with:
 - Success/failure status
 - Runtime metrics
-- Security findings count
+- Findings count
 - Detailed findings with file, line, severity, and descriptions
 
 Example output file: `pr_example_repo_123.json`
@@ -49,4 +49,4 @@ The evaluation tool uses git worktrees for efficient repository management:
 1. Clones the repository once as a base
 2. Creates lightweight worktrees for each PR evaluation
 3. Automatically handles cleanup of worktrees
-4. Runs the SAST audit in the PR-specific worktree
+4. Runs the review in the PR-specific worktree

--- a/claudecode/evals/__init__.py
+++ b/claudecode/evals/__init__.py
@@ -1,4 +1,4 @@
-"""Evaluation tool for SAST."""
+"""Evaluation tool for code review."""
 
 from .eval_engine import EvalCase, EvalResult, EvaluationEngine, run_single_evaluation
 

--- a/claudecode/evals/run_eval.py
+++ b/claudecode/evals/run_eval.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CLI for running SAST evaluation on a single PR."""
+"""CLI for running code review evaluation on a single PR."""
 
 import argparse
 import os
@@ -31,7 +31,7 @@ class EvalResult:
     success: bool
     runtime_seconds: float
     findings_count: int
-    detected_vulnerabilities: bool
+    detected_issues: bool
     
     # Optional fields
     error_message: str = ""
@@ -44,9 +44,9 @@ class EvalResult:
 
 
 def main():
-    """Main entry point for single PR SAST evaluation."""
+    """Main entry point for single PR code review evaluation."""
     parser = argparse.ArgumentParser(
-        description="Run SAST security evaluation on a single GitHub PR",
+        description="Run code review evaluation on a single GitHub PR",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     
@@ -126,7 +126,7 @@ def main():
     print("EVALUATION RESULTS:")
     print(f"Success: {result.success}")
     print(f"Runtime: {result.runtime_seconds:.1f} seconds")
-    print(f"Vulnerabilities detected: {result.detected_vulnerabilities}")
+    print(f"Issues detected: {result.detected_issues}")
     print(f"Findings count: {result.findings_count}")
     
     if result.error_message:
@@ -140,8 +140,10 @@ def main():
                 print(f"    Category: {finding['category']}")
             if 'description' in finding:
                 print(f"    Description: {finding['description']}")
-            if 'exploit_scenario' in finding:
-                print(f"    Exploit: {finding['exploit_scenario']}")
+            if 'impact' in finding:
+                print(f"    Impact: {finding['impact']}")
+            elif 'exploit_scenario' in finding:
+                print(f"    Impact: {finding['exploit_scenario']}")
             if 'recommendation' in finding:
                 print(f"    Fix: {finding['recommendation']}")
             if 'confidence' in finding:

--- a/claudecode/github_action_audit.py
+++ b/claudecode/github_action_audit.py
@@ -641,7 +641,6 @@ def main():
                         pr_diff,
                         include_diff=include_diff,
                         custom_review_instructions=custom_review_instructions,
-                        custom_security_instructions=custom_security_instructions,
                     ),
                 )
                 pass_summaries['general'] = general_results.get('analysis_summary', {})

--- a/claudecode/prompts.py
+++ b/claudecode/prompts.py
@@ -1,20 +1,28 @@
-"""Security audit prompt templates."""
+"""Code review prompt templates."""
 
-def get_security_audit_prompt(pr_data, pr_diff=None, include_diff=True, custom_scan_instructions=None):
-    """Generate security audit prompt for Claude Code.
-    
+
+def get_code_review_prompt(
+    pr_data,
+    pr_diff=None,
+    include_diff=True,
+    custom_review_instructions=None,
+    custom_security_instructions=None,
+):
+    """Generate code review prompt for Claude Code.
+
     Args:
         pr_data: PR data dictionary from GitHub API
         pr_diff: Optional complete PR diff in unified format
         include_diff: Whether to include the diff in the prompt (default: True)
-        custom_scan_instructions: Optional custom security categories to append
-        
+        custom_review_instructions: Optional custom review instructions to append
+        custom_security_instructions: Optional custom security categories to append
+
     Returns:
         Formatted prompt string
     """
-    
+
     files_changed = "\n".join([f"- {f['filename']}" for f in pr_data['files']])
-    
+
     # Add diff section if provided and include_diff is True
     diff_section = ""
     if pr_diff and include_diff:
@@ -32,12 +40,173 @@ Review the complete diff above. This contains all code changes in the PR.
 
 NOTE: PR diff was omitted due to size constraints. Please use the file exploration tools to examine the specific files that were changed in this PR.
 """
-    
-    # Add custom security categories if provided
-    custom_categories_section = ""
-    if custom_scan_instructions:
-        custom_categories_section = f"\n{custom_scan_instructions}\n"
-    
+
+    # Add custom instructions if provided
+    custom_review_section = ""
+    if custom_review_instructions:
+        custom_review_section = f"\n{custom_review_instructions}\n"
+
+    custom_security_section = ""
+    if custom_security_instructions:
+        custom_security_section = f"\n{custom_security_instructions}\n"
+
+    return f"""
+You are a senior engineer conducting a high-signal code review of GitHub PR #{pr_data['number']}: "{pr_data['title']}"
+
+CONTEXT:
+- Repository: {pr_data.get('head', {}).get('repo', {}).get('full_name', 'unknown')}
+- Author: {pr_data['user']}
+- Files changed: {pr_data['changed_files']}
+- Lines added: {pr_data['additions']}
+- Lines deleted: {pr_data['deletions']}
+
+Files modified:
+{files_changed}{diff_section}
+
+OBJECTIVE:
+Perform a focused, high-signal code review to identify HIGH-CONFIDENCE issues introduced by this PR. This includes correctness, reliability, performance, maintainability, testing, and security. Do not comment on pre-existing issues or purely stylistic preferences.
+
+CRITICAL INSTRUCTIONS:
+1. MINIMIZE FALSE POSITIVES: Only flag issues where you're >80% confident they are real and impactful
+2. AVOID NOISE: Skip style nits, subjective preferences, or low-impact suggestions
+3. FOCUS ON IMPACT: Prioritize bugs, regressions, security risks, data loss, or significant performance problems
+4. SCOPE: Only evaluate code introduced or modified in this PR. Ignore unrelated existing issues
+
+REVIEW CATEGORIES TO EXAMINE:
+
+**Correctness & Logic:**
+- Incorrect business logic or wrong results
+- Edge cases or null/empty handling regressions
+- Incorrect error handling or missing validations leading to bad state
+- Invariants broken by changes
+
+**Reliability & Resilience:**
+- Concurrency or race conditions introduced by changes
+- Resource leaks, timeouts, or missing retries in critical paths
+- Partial failure handling or inconsistent state updates
+- Idempotency or ordering issues
+
+**Performance & Scalability:**
+- Algorithmic regressions in hot paths (O(n^2) where O(n) expected)
+- N+1 query patterns
+- Excessive synchronous I/O in latency-sensitive code
+- Unbounded memory growth introduced by changes
+
+**Maintainability & Design:**
+- Changes that significantly increase complexity or make future changes risky
+- Tight coupling or unclear responsibility boundaries introduced
+- Misleading APIs or brittle contracts
+
+**Testing & Observability:**
+- Missing tests for high-risk changes
+- Lack of logging/metrics around new critical behavior
+- Flaky behavior due to nondeterministic changes
+
+**Security:**
+- Injection risks (SQL/command/template/NoSQL)
+- Authentication or authorization bypass
+- Unsafe deserialization or dynamic code execution
+- Sensitive data exposure or insecure crypto usage
+{custom_security_section}
+{custom_review_section}
+Additional notes:
+- Even if something is only exploitable from the local network, it can still be a HIGH severity issue
+
+ANALYSIS METHODOLOGY:
+
+Phase 1 - Repository Context Research (Use file search tools):
+- Identify existing patterns, conventions, and critical paths
+- Understand data flow, invariants, and error handling expectations
+- Note existing testing and observability practices
+
+Phase 2 - Comparative Analysis:
+- Compare new changes to existing patterns and contracts
+- Identify deviations that introduce risk or regressions
+- Look for inconsistent handling between similar code paths
+
+Phase 3 - Issue Assessment:
+- Examine each modified file for correctness, reliability, performance, maintainability, testing, and security implications
+- Trace data flow from inputs to sensitive or critical operations
+- Identify concurrency and state management risks
+
+REQUIRED OUTPUT FORMAT:
+
+You MUST output your findings as structured JSON with this exact schema:
+
+{{
+  "findings": [
+    {{
+      "file": "path/to/file.py",
+      "line": 42,
+      "severity": "HIGH",
+      "category": "security|correctness|reliability|performance|maintainability|testing",
+      "title": "Short summary of the issue",
+      "description": "What is wrong and where it happens",
+      "impact": "Concrete impact or failure mode (use exploit scenario for security issues)",
+      "recommendation": "Actionable fix or mitigation",
+      "confidence": 0.95
+    }}
+  ],
+  "analysis_summary": {{
+    "files_reviewed": 8,
+    "high_severity": 1,
+    "medium_severity": 0,
+    "low_severity": 0,
+    "review_completed": true,
+  }}
+}}
+
+SEVERITY GUIDELINES:
+- **HIGH**: Likely production bug, data loss, security vulnerability, auth bypass, or significant regression
+- **MEDIUM**: Real issue with limited scope or specific triggering conditions
+- **LOW**: Minor but real issue; use sparingly and only if clearly actionable
+
+CONFIDENCE SCORING:
+- 0.9-1.0: Certain issue with clear evidence and impact
+- 0.8-0.9: Strong signal with likely real-world impact
+- 0.7-0.8: Plausible issue but may require specific conditions
+- Below 0.7: Don't report (too speculative)
+
+FINAL REMINDER:
+Focus on HIGH and MEDIUM findings only. Better to miss some theoretical issues than flood the report with false positives. Each finding should be something a senior engineer would confidently raise in a PR review.
+
+Begin your analysis now. Use the repository exploration tools to understand the codebase context, then analyze the PR changes for code review implications.
+
+Your final reply must contain the JSON and nothing else. You should not reply again after outputting the JSON.
+"""
+
+
+def get_security_review_prompt(
+    pr_data,
+    pr_diff=None,
+    include_diff=True,
+    custom_security_instructions=None,
+):
+    """Generate security-focused review prompt for Claude Code."""
+
+    files_changed = "\n".join([f"- {f['filename']}" for f in pr_data['files']])
+
+    diff_section = ""
+    if pr_diff and include_diff:
+        diff_section = f"""
+
+PR DIFF CONTENT:
+```
+{pr_diff}
+```
+
+Review the complete diff above. This contains all code changes in the PR.
+"""
+    elif pr_diff and not include_diff:
+        diff_section = """
+
+NOTE: PR diff was omitted due to size constraints. Please use the file exploration tools to examine the specific files that were changed in this PR.
+"""
+
+    custom_security_section = ""
+    if custom_security_instructions:
+        custom_security_section = f"\n{custom_security_instructions}\n"
+
     return f"""
 You are a senior security engineer conducting a focused security review of GitHub PR #{pr_data['number']}: "{pr_data['title']}"
 
@@ -52,7 +221,7 @@ Files modified:
 {files_changed}{diff_section}
 
 OBJECTIVE:
-Perform a security-focused code review to identify HIGH-CONFIDENCE security vulnerabilities that could have real exploitation potential. This is not a general code review - focus ONLY on security implications newly added by this PR. Do not comment on existing security concerns.
+Perform a security-focused code review to identify HIGH-CONFIDENCE security vulnerabilities newly introduced by this PR. Do not comment on pre-existing issues or general code quality.
 
 CRITICAL INSTRUCTIONS:
 1. MINIMIZE FALSE POSITIVES: Only flag issues where you're >80% confident of actual exploitability
@@ -88,7 +257,7 @@ SECURITY CATEGORIES TO EXAMINE:
 - Certificate validation bypasses
 
 **Injection & Code Execution:**
-- Remote code execution via deseralization
+- Remote code execution via deserialization
 - Pickle injection in Python
 - YAML deserialization vulnerabilities
 - Eval injection in dynamic code execution
@@ -99,7 +268,7 @@ SECURITY CATEGORIES TO EXAMINE:
 - PII handling violations
 - API endpoint data leakage
 - Debug information exposure
-{custom_categories_section}
+{custom_security_section}
 Additional notes:
 - Even if something is only exploitable from the local network, it can still be a HIGH severity issue
 
@@ -133,10 +302,11 @@ You MUST output your findings as structured JSON with this exact schema:
       "file": "path/to/file.py",
       "line": 42,
       "severity": "HIGH",
-      "category": "sql_injection",
-      "description": "User input passed to SQL query without parameterization",
-      "exploit_scenario": "Attacker could extract database contents by manipulating the 'search' parameter with SQL injection payloads like '1; DROP TABLE users--'",
-      "recommendation": "Replace string formatting with parameterized queries using SQLAlchemy or equivalent",
+      "category": "security",
+      "title": "Short summary of the issue",
+      "description": "What is wrong and where it happens",
+      "impact": "Exploit scenario or concrete impact",
+      "recommendation": "Actionable fix or mitigation",
       "confidence": 0.95
     }}
   ],
@@ -156,7 +326,7 @@ SEVERITY GUIDELINES:
 
 CONFIDENCE SCORING:
 - 0.9-1.0: Certain exploit path identified, tested if possible
-- 0.8-0.9: Clear vulnerability pattern with known exploitation methods  
+- 0.8-0.9: Clear vulnerability pattern with known exploitation methods
 - 0.7-0.8: Suspicious pattern requiring specific conditions to exploit
 - Below 0.7: Don't report (too speculative)
 
@@ -166,11 +336,21 @@ Focus on HIGH and MEDIUM findings only. Better to miss some theoretical issues t
 IMPORTANT EXCLUSIONS - DO NOT REPORT:
 - Denial of Service (DOS) vulnerabilities or resource exhaustion attacks
 - Secrets/credentials stored on disk (these are managed separately)
-- Rate limiting concerns or service overload scenarios. Services do not need to implement rate limiting.
-- Memory consumption or CPU exhaustion issues.
-- Lack of input validation on non-security-critical fields. If there isn't a proven problem from a lack of input validation, don't report it.
+- Rate limiting concerns or service overload scenarios
+- Memory consumption or CPU exhaustion issues
+- Lack of input validation on non-security-critical fields without proven security impact
 
 Begin your analysis now. Use the repository exploration tools to understand the codebase context, then analyze the PR changes for security implications.
 
 Your final reply must contain the JSON and nothing else. You should not reply again after outputting the JSON.
 """
+
+
+def get_security_audit_prompt(pr_data, pr_diff=None, include_diff=True, custom_scan_instructions=None):
+    """Backward-compatible wrapper for previous security-only prompt."""
+    return get_security_review_prompt(
+        pr_data,
+        pr_diff=pr_diff,
+        include_diff=include_diff,
+        custom_security_instructions=custom_scan_instructions,
+    )

--- a/claudecode/prompts.py
+++ b/claudecode/prompts.py
@@ -152,7 +152,7 @@ You MUST output your findings as structured JSON with this exact schema:
     "high_severity": 1,
     "medium_severity": 0,
     "low_severity": 0,
-    "review_completed": true,
+    "review_completed": true
   }}
 }}
 
@@ -315,7 +315,7 @@ You MUST output your findings as structured JSON with this exact schema:
     "high_severity": 1,
     "medium_severity": 0,
     "low_severity": 0,
-    "review_completed": true,
+    "review_completed": true
   }}
 }}
 

--- a/claudecode/requirements.txt
+++ b/claudecode/requirements.txt
@@ -1,4 +1,4 @@
-# Requirements for claudecode - Claude Code PR Security Audit Tool
+# Requirements for claudecode - Claude Code PR Review Tool
 # Core dependencies for the GitHub Action version
 
 # GitHub API client
@@ -15,4 +15,4 @@ requests>=2.28.0
 anthropic>=0.39.0
 
 # Note: Claude CLI tool must be installed separately
-# The claude command-line tool is required for security analysis
+# The claude command-line tool is required for review analysis

--- a/claudecode/test_findings_conversion.py
+++ b/claudecode/test_findings_conversion.py
@@ -126,7 +126,7 @@ class TestFindingsConversionEdgeCases:
             {'severity': 'HIGH', 'description': 'Issue with [brackets] and (parens)'},
             {'severity': 'HIGH', 'description': 'Path: C:\\Users\\test\\file.py'},
             {'severity': 'HIGH', 'description': 'Regex pattern: .*$^[]{}'},
-            {'severity': 'HIGH', 'description': 'Missing rate limiting for API'},
+            {'severity': 'HIGH', 'description': 'Missing rate limiting for API', 'category': 'security'},
         ]
         
         filter = create_simple_filter()
@@ -139,10 +139,10 @@ class TestFindingsConversionEdgeCases:
     def test_case_sensitivity_in_exclusions(self):
         """Test case sensitivity in exclusion rules."""
         findings = [
-            {'severity': 'HIGH', 'description': 'DENIAL OF SERVICE attack'},
-            {'severity': 'HIGH', 'description': 'Denial Of Service issue'},
-            {'severity': 'HIGH', 'description': 'dos vulnerability'},
-            {'severity': 'HIGH', 'description': 'DoS attack vector'},
+            {'severity': 'HIGH', 'description': 'DENIAL OF SERVICE attack', 'category': 'security'},
+            {'severity': 'HIGH', 'description': 'Denial Of Service issue', 'category': 'security'},
+            {'severity': 'HIGH', 'description': 'dos vulnerability', 'category': 'security'},
+            {'severity': 'HIGH', 'description': 'DoS attack vector', 'category': 'security'},
         ]
         
         filter = create_simple_filter()
@@ -298,7 +298,8 @@ class TestHardExclusionRulesEdgeCases:
         """Test findings that match multiple exclusion patterns."""
         finding = {
             'severity': 'HIGH',
-            'description': 'Denial of service via rate limiting bypass allows brute force attack'
+            'description': 'Denial of service via rate limiting bypass allows brute force attack',
+            'category': 'security'
         }
         
         # Matches both DOS and rate limiting patterns
@@ -309,9 +310,9 @@ class TestHardExclusionRulesEdgeCases:
     def test_pattern_boundary_matching(self):
         """Test pattern matching at word boundaries."""
         findings = [
-            {'severity': 'HIGH', 'description': 'dosomething() function'},  # Should not match DOS
-            {'severity': 'HIGH', 'description': 'windows path issue'},  # Should not match
-            {'severity': 'HIGH', 'description': 'pseudorandom number'},  # Should not match
+            {'severity': 'HIGH', 'description': 'dosomething() function', 'category': 'security'},  # Should not match DOS
+            {'severity': 'HIGH', 'description': 'windows path issue', 'category': 'security'},  # Should not match
+            {'severity': 'HIGH', 'description': 'pseudorandom number', 'category': 'security'},  # Should not match
         ]
         
         filter = create_simple_filter()
@@ -324,8 +325,8 @@ class TestHardExclusionRulesEdgeCases:
     def test_html_entities_in_description(self):
         """Test findings with HTML entities."""
         findings = [
-            {'severity': 'HIGH', 'description': 'XSS via &lt;script&gt; tag'},
-            {'severity': 'HIGH', 'description': 'Missing rate limiting &amp; throttling'},
+            {'severity': 'HIGH', 'description': 'XSS via &lt;script&gt; tag', 'category': 'security'},
+            {'severity': 'HIGH', 'description': 'Missing rate limiting &amp; throttling', 'category': 'security'},
         ]
         
         filter = create_simple_filter()
@@ -343,13 +344,15 @@ class TestHardExclusionRulesEdgeCases:
                 'severity': 'HIGH',
                 'description': '''SQL injection vulnerability
                 in user input handling.
-                This could lead to data exposure.'''
+                This could lead to data exposure.''',
+                'category': 'security'
             },
             {
                 'severity': 'HIGH',
                 'description': '''Performance issue that could
                 cause denial of service under
-                heavy load conditions.'''
+                heavy load conditions.''',
+                'category': 'security'
             }
         ]
         
@@ -368,13 +371,13 @@ class TestFilteringCombinations:
     def test_mixed_valid_invalid_findings(self):
         """Test mix of valid, invalid, and excludable findings."""
         findings = [
-            {'severity': 'HIGH', 'description': 'SQL injection'},  # Valid
+            {'severity': 'HIGH', 'description': 'SQL injection', 'category': 'security'},  # Valid
             {'description': 'Missing severity'},  # Valid (no exclusion pattern)
-            {'severity': 'HIGH', 'description': 'Missing rate limiting'},  # Excludable
-            {'severity': 'MEDIUM', 'description': 'XSS vulnerability'},  # Valid
-            {'severity': 'LOW', 'description': 'Denial of service attack'},  # Excludable
+            {'severity': 'HIGH', 'description': 'Missing rate limiting', 'category': 'security'},  # Excludable
+            {'severity': 'MEDIUM', 'description': 'XSS vulnerability', 'category': 'security'},  # Valid
+            {'severity': 'LOW', 'description': 'Denial of service attack', 'category': 'security'},  # Excludable
             {'severity': '', 'description': ''},  # Valid (no exclusion pattern)
-            {'severity': 'HIGH', 'description': 'RCE possibility'},  # Valid
+            {'severity': 'HIGH', 'description': 'RCE possibility', 'category': 'security'},  # Valid
         ]
         
         filter = create_simple_filter()

--- a/claudecode/test_github_action_audit.py
+++ b/claudecode/test_github_action_audit.py
@@ -17,11 +17,12 @@ class TestImports:
     
     def test_component_imports(self):
         """Test that all component modules can be imported."""
-        from claudecode.prompts import get_security_audit_prompt
+        from claudecode.prompts import get_code_review_prompt, get_security_review_prompt
         from claudecode.json_parser import parse_json_with_fallbacks, extract_json_from_text
         
         # Verify they're callable/usable
-        assert callable(get_security_audit_prompt)
+        assert callable(get_code_review_prompt)
+        assert callable(get_security_review_prompt)
         assert callable(parse_json_with_fallbacks)
         assert callable(extract_json_from_text)
 
@@ -34,9 +35,9 @@ class TestHardExclusionRules:
         from claudecode.findings_filter import HardExclusionRules
         
         dos_findings = [
-            {'description': 'Potential denial of service vulnerability'},
-            {'description': 'DOS attack through resource exhaustion'},
-            {'description': 'Infinite loop causing resource exhaustion'},
+            {'description': 'Potential denial of service vulnerability', 'category': 'security'},
+            {'description': 'DOS attack through resource exhaustion', 'category': 'security'},
+            {'description': 'Infinite loop causing resource exhaustion', 'category': 'security'},
         ]
         
         for finding in dos_findings:
@@ -49,9 +50,9 @@ class TestHardExclusionRules:
         from claudecode.findings_filter import HardExclusionRules
         
         rate_limit_findings = [
-            {'description': 'Missing rate limiting on endpoint'},
-            {'description': 'No rate limit implemented for API'},
-            {'description': 'Implement rate limiting for this route'},
+            {'description': 'Missing rate limiting on endpoint', 'category': 'security'},
+            {'description': 'No rate limit implemented for API', 'category': 'security'},
+            {'description': 'Implement rate limiting for this route', 'category': 'security'},
         ]
         
         for finding in rate_limit_findings:
@@ -64,9 +65,9 @@ class TestHardExclusionRules:
         from claudecode.findings_filter import HardExclusionRules
         
         redirect_findings = [
-            {'description': 'Open redirect vulnerability found'},
-            {'description': 'Unvalidated redirect in URL parameter'},
-            {'description': 'Redirect attack possible through user input'},
+            {'description': 'Open redirect vulnerability found', 'category': 'security'},
+            {'description': 'Unvalidated redirect in URL parameter', 'category': 'security'},
+            {'description': 'Redirect attack possible through user input', 'category': 'security'},
         ]
         
         for finding in redirect_findings:
@@ -79,10 +80,10 @@ class TestHardExclusionRules:
         from claudecode.findings_filter import HardExclusionRules
         
         md_findings = [
-            {'file': 'README.md', 'description': 'SQL injection vulnerability'},
-            {'file': 'docs/security.md', 'description': 'Command injection found'},
-            {'file': 'CHANGELOG.MD', 'description': 'XSS vulnerability'},  # Test case insensitive
-            {'file': 'path/to/file.Md', 'description': 'Path traversal'},  # Mixed case
+            {'file': 'README.md', 'description': 'SQL injection vulnerability', 'category': 'security'},
+            {'file': 'docs/security.md', 'description': 'Command injection found', 'category': 'security'},
+            {'file': 'CHANGELOG.MD', 'description': 'XSS vulnerability', 'category': 'security'},  # Test case insensitive
+            {'file': 'path/to/file.Md', 'description': 'Path traversal', 'category': 'security'},  # Mixed case
         ]
         
         for finding in md_findings:
@@ -115,10 +116,10 @@ class TestHardExclusionRules:
         from claudecode.findings_filter import HardExclusionRules
         
         real_vulns = [
-            {'file': 'auth.py', 'description': 'SQL injection in user authentication'},
-            {'file': 'exec.js', 'description': 'Command injection through user input'},
-            {'file': 'comments.php', 'description': 'Cross-site scripting in comment field'},
-            {'file': 'upload.go', 'description': 'Path traversal in file upload'},
+            {'file': 'auth.py', 'description': 'SQL injection in user authentication', 'category': 'security'},
+            {'file': 'exec.js', 'description': 'Command injection through user input', 'category': 'security'},
+            {'file': 'comments.php', 'description': 'Cross-site scripting in comment field', 'category': 'security'},
+            {'file': 'upload.go', 'description': 'Path traversal in file upload', 'category': 'security'},
         ]
         
         for finding in real_vulns:
@@ -172,9 +173,9 @@ class TestJSONParser:
 class TestPromptsModule:
     """Test the prompts module."""
     
-    def test_get_security_audit_prompt(self):
+    def test_get_code_review_prompt(self):
         """Test security audit prompt generation."""
-        from claudecode.prompts import get_security_audit_prompt
+        from claudecode.prompts import get_code_review_prompt
         
         pr_data = {
             'number': 123,
@@ -202,7 +203,7 @@ class TestPromptsModule:
         
         pr_diff = "diff --git a/test.py b/test.py\n+added line"
         
-        prompt = get_security_audit_prompt(pr_data, pr_diff)
+        prompt = get_code_review_prompt(pr_data, pr_diff)
         
         assert isinstance(prompt, str)
         assert 'security' in prompt.lower()
@@ -259,4 +260,3 @@ class TestDeploymentPRDetection:
         
         for title in non_deployment_titles:
             assert not re.match(deployment_pattern, title, re.IGNORECASE), f"Incorrectly matched non-deployment PR: {title}"
-

--- a/claudecode/test_hard_exclusion_rules.py
+++ b/claudecode/test_hard_exclusion_rules.py
@@ -11,19 +11,23 @@ class TestHardExclusionRules:
         dos_findings = [
             {
                 "title": "Potential Denial of Service",
-                "description": "This could lead to resource exhaustion"
+                "description": "This could lead to resource exhaustion",
+                "category": "security"
             },
             {
                 "title": "Resource consumption issue",
-                "description": "Unbounded loop could exhaust CPU resources"
+                "description": "Unbounded loop could exhaust CPU resources",
+                "category": "security"
             },
             {
                 "title": "Memory exhaustion",
-                "description": "This function could overwhelm memory with large inputs"
+                "description": "This function could overwhelm memory with large inputs",
+                "category": "security"
             },
             {
                 "title": "Stack overflow vulnerability",
-                "description": "Infinite recursion detected"
+                "description": "Infinite recursion detected",
+                "category": "security"
             }
         ]
         
@@ -37,7 +41,8 @@ class TestHardExclusionRules:
         finding = {
             "title": "Stack overflow exploit",
             "description": "This stack overflow can be exploited to execute arbitrary code",
-            "file": "exploit.c"  # Add C file so it's not excluded by memory safety rule
+            "file": "exploit.c",  # Add C file so it's not excluded by memory safety rule
+            "category": "security"
         }
         
         reason = HardExclusionRules.get_exclusion_reason(finding)
@@ -146,19 +151,23 @@ class TestHardExclusionRules:
         rate_limit_findings = [
             {
                 "title": "Missing rate limit",
-                "description": "API endpoint has no rate limiting"
+                "description": "API endpoint has no rate limiting",
+                "category": "security"
             },
             {
                 "title": "Rate limiting required",
-                "description": "Implement rate limiting for this endpoint"
+                "description": "Implement rate limiting for this endpoint",
+                "category": "security"
             },
             {
                 "title": "No rate limit",
-                "description": "Unlimited requests allowed"
+                "description": "Unlimited requests allowed",
+                "category": "security"
             },
             {
                 "title": "Add rate limiting",
-                "description": "This API needs rate limits"
+                "description": "This API needs rate limits",
+                "category": "security"
             }
         ]
         
@@ -172,19 +181,23 @@ class TestHardExclusionRules:
         resource_findings = [
             {
                 "title": "Security Issue",
-                "description": "Potential memory leak detected"
+                "description": "Potential memory leak detected",
+                "category": "security"
             },
             {
                 "title": "Security Issue",
-                "description": "Resource leak potential in file handling"
+                "description": "Resource leak potential in file handling",
+                "category": "security"
             },
             {
                 "title": "Security Issue",
-                "description": "Unclosed resource detected in function"
+                "description": "Unclosed resource detected in function",
+                "category": "security"
             },
             {
                 "title": "Security Issue",
-                "description": "File cleanup required - close resource"
+                "description": "File cleanup required - close resource",
+                "category": "security"
             }
         ]
         
@@ -192,21 +205,43 @@ class TestHardExclusionRules:
             reason = HardExclusionRules.get_exclusion_reason(finding)
             assert reason is not None
             assert "Resource management finding" in reason
+
+    def test_resource_pattern_not_excluded_for_non_security(self):
+        """Test that resource issues are kept for non-security categories."""
+        resource_findings = [
+            {
+                "title": "Potential memory leak detected",
+                "description": "Connections are not closed on error paths",
+                "category": "reliability"
+            },
+            {
+                "title": "Resource leak potential",
+                "description": "File handles remain open after exceptions",
+                "category": "performance"
+            }
+        ]
+
+        for finding in resource_findings:
+            reason = HardExclusionRules.get_exclusion_reason(finding)
+            assert reason is None
     
     def test_specific_resource_also_excluded(self):
         """Test that ALL resource issues are now excluded (including specific ones)."""
         specific_resources = [
             {
                 "title": "Database connection leak",
-                "description": "PostgreSQL connections not returned to pool"
+                "description": "PostgreSQL connections not returned to pool",
+                "category": "security"
             },
             {
                 "title": "Thread leak",
-                "description": "Thread pool exhaustion due to unclosed threads"
+                "description": "Thread pool exhaustion due to unclosed threads",
+                "category": "security"
             },
             {
                 "title": "Socket leak",
-                "description": "TCP sockets remain open after errors"
+                "description": "TCP sockets remain open after errors",
+                "category": "security"
             }
         ]
         
@@ -221,19 +256,23 @@ class TestHardExclusionRules:
         redirect_findings = [
             {
                 "title": "Open redirect vulnerability",
-                "description": "User input used in redirect without validation"
+                "description": "User input used in redirect without validation",
+                "category": "security"
             },
             {
                 "title": "Unvalidated redirect",
-                "description": "Redirect URL not validated"
+                "description": "Redirect URL not validated",
+                "category": "security"
             },
             {
                 "title": "Redirect vulnerability",
-                "description": "Possible redirect attack"
+                "description": "Possible redirect attack",
+                "category": "security"
             },
             {
                 "title": "Malicious redirect possible",
-                "description": "User-controlled redirect parameter"
+                "description": "User-controlled redirect parameter",
+                "category": "security"
             }
         ]
         
@@ -247,11 +286,13 @@ class TestHardExclusionRules:
         mixed_case_findings = [
             {
                 "title": "DENIAL OF SERVICE",
-                "description": "RESOURCE EXHAUSTION POSSIBLE"
+                "description": "RESOURCE EXHAUSTION POSSIBLE",
+                "category": "security"
             },
             {
                 "title": "Security Issue",
-                "description": "ADD INPUT VALIDATION"
+                "description": "ADD INPUT VALIDATION",
+                "category": "security"
             },
             {
                 "title": "Security Issue",
@@ -289,7 +330,8 @@ class TestHardExclusionRules:
         """Test findings that match multiple patterns."""
         finding = {
             "title": "DOS and validation issue",
-            "description": "Missing rate limit leads to resource exhaustion"
+            "description": "Missing rate limit leads to resource exhaustion",
+            "category": "security"
         }
         
         reason = HardExclusionRules.get_exclusion_reason(finding)
@@ -324,7 +366,8 @@ class TestHardExclusionRules:
         long_text = "A" * 10000  # 10k characters
         finding = {
             "title": "Long finding",
-            "description": long_text + " denial of service " + long_text
+            "description": long_text + " denial of service " + long_text,
+            "category": "security"
         }
         
         # Should handle long text efficiently
@@ -338,27 +381,32 @@ class TestHardExclusionRules:
             {
                 "title": "Buffer overflow vulnerability",
                 "description": "Potential buffer overflow in string handling",
-                "file": "app.py"
+                "file": "app.py",
+                "category": "security"
             },
             {
                 "title": "Out of bounds access",
                 "description": "Array out of bounds write detected",
-                "file": "server.js"
+                "file": "server.js",
+                "category": "security"
             },
             {
                 "title": "Memory corruption",
                 "description": "Use after free vulnerability found",
-                "file": "Main.java"
+                "file": "Main.java",
+                "category": "security"
             },
             {
                 "title": "Segmentation fault",
                 "description": "Null pointer dereference causes segfault",
-                "file": "handler.go"
+                "file": "handler.go",
+                "category": "security"
             },
             {
                 "title": "Integer overflow",
                 "description": "Integer overflow in calculation",
-                "file": "calc.rb"
+                "file": "calc.rb",
+                "category": "security"
             }
         ]
         
@@ -373,22 +421,26 @@ class TestHardExclusionRules:
             {
                 "title": "Buffer overflow",
                 "description": "Stack buffer overflow in strcpy",
-                "file": "main.c"
+                "file": "main.c",
+                "category": "security"
             },
             {
                 "title": "Out of bounds write",
                 "description": "Array index out of bounds",
-                "file": "parser.cc"
+                "file": "parser.cc",
+                "category": "security"
             },
             {
                 "title": "Memory safety",
                 "description": "Use after free in destructor",
-                "file": "object.cpp"
+                "file": "object.cpp",
+                "category": "security"
             },
             {
                 "title": "Bounds check missing",
                 "description": "No bounds checking on user input",
-                "file": "input.h"
+                "file": "input.h",
+                "category": "security"
             }
         ]
         
@@ -402,12 +454,14 @@ class TestHardExclusionRules:
             {
                 "title": "Buffer overflow",
                 "description": "Buffer overflow detected",
-                "file": "App.PY"  # Uppercase extension
+                "file": "App.PY",  # Uppercase extension
+                "category": "security"
             },
             {
                 "title": "Memory corruption",
                 "description": "Memory corruption issue",
-                "file": "SERVER.JS"  # All uppercase
+                "file": "SERVER.JS",  # All uppercase
+                "category": "security"
             }
         ]
         
@@ -422,12 +476,14 @@ class TestHardExclusionRules:
             {
                 "title": "Buffer overflow",
                 "description": "Buffer overflow detected",
-                "file": "Makefile"  # No extension
+                "file": "Makefile",  # No extension
+                "category": "security"
             },
             {
                 "title": "Memory corruption",
                 "description": "Memory corruption issue",
-                "file": ""  # Empty file path
+                "file": "",  # Empty file path
+                "category": "security"
             }
         ]
         

--- a/claudecode/test_helper_functions.py
+++ b/claudecode/test_helper_functions.py
@@ -9,7 +9,7 @@ from claudecode.github_action_audit import (
     get_environment_config,
     initialize_clients,
     initialize_findings_filter,
-    run_security_audit,
+    run_code_review,
     apply_findings_filter,
     ConfigurationError,
     AuditError
@@ -143,33 +143,33 @@ class TestHelperFunctions:
             
             assert result == mock_filter_instance
     
-    def test_run_security_audit_success(self):
-        """Test successful security audit execution."""
+    def test_run_code_review_success(self):
+        """Test successful code review execution."""
         mock_runner = MagicMock()
-        mock_runner.run_security_audit.return_value = (
+        mock_runner.run_code_review.return_value = (
             True,
             "",
             {"findings": [{"id": 1}], "analysis_summary": {}}
         )
         
-        result = run_security_audit(mock_runner, "test prompt")
+        result = run_code_review(mock_runner, "test prompt")
         
         assert result == {"findings": [{"id": 1}], "analysis_summary": {}}
-        mock_runner.run_security_audit.assert_called_once()
+        mock_runner.run_code_review.assert_called_once()
     
-    def test_run_security_audit_failure(self):
-        """Test security audit execution failure."""
+    def test_run_code_review_failure(self):
+        """Test code review execution failure."""
         mock_runner = MagicMock()
-        mock_runner.run_security_audit.return_value = (
+        mock_runner.run_code_review.return_value = (
             False,
             "Audit failed: timeout",
             {}
         )
         
         with pytest.raises(AuditError) as exc_info:
-            run_security_audit(mock_runner, "test prompt")
+            run_code_review(mock_runner, "test prompt")
         
-        assert "Security audit failed: Audit failed: timeout" in str(exc_info.value)
+        assert "Code review failed: Audit failed: timeout" in str(exc_info.value)
     
     def test_apply_findings_filter_with_findings_filter(self):
         """Test applying FindingsFilter to findings."""

--- a/claudecode/test_integration.py
+++ b/claudecode/test_integration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Pytest tests for SAST integration components.
+Pytest tests for code review integration components.
 """
 
 import pytest
@@ -94,8 +94,8 @@ class TestFilteringIntegration:
         )
         
         test_findings = [
-            {'description': 'SQL injection vulnerability', 'severity': 'HIGH'},
-            {'description': 'Missing rate limiting', 'severity': 'MEDIUM'},
+            {'description': 'SQL injection vulnerability', 'severity': 'HIGH', 'category': 'security'},
+            {'description': 'Missing rate limiting', 'severity': 'MEDIUM', 'category': 'security'},
         ]
         
         success, results, stats = filter_instance.filter_findings(test_findings)

--- a/claudecode/test_workflow_integration.py
+++ b/claudecode/test_workflow_integration.py
@@ -181,7 +181,7 @@ index 8901234..5678901 100644
         audit_result.stdout = json.dumps(claude_wrapped_response)
         audit_result.stderr = ''
         
-        # The audit might be retried, so provide the same result twice
+        # Provide results for general and security passes
         mock_run.side_effect = [version_result, audit_result, audit_result]
         
         # Run the workflow
@@ -203,7 +203,7 @@ index 8901234..5678901 100644
         
         # Verify API calls
         assert mock_get.call_count == 3
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         
         # Verify the audit was run with proper prompt
         audit_call = mock_run.call_args_list[1]
@@ -261,7 +261,8 @@ index 8901234..5678901 100644
         
         mock_run.side_effect = [
             Mock(returncode=0, stdout='claude version 1.0.0', stderr=''),
-            Mock(returncode=0, stdout=json.dumps({"findings": claude_findings}), stderr='')
+            Mock(returncode=0, stdout=json.dumps({"findings": claude_findings}), stderr=''),
+            Mock(returncode=0, stdout=json.dumps({"findings": []}), stderr='')
         ]
         
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -298,8 +299,8 @@ index 8901234..5678901 100644
     
     @patch('subprocess.run')
     @patch('requests.get')
-    def test_workflow_with_no_security_issues(self, mock_get, mock_run):
-        """Test workflow when no security issues are found."""
+    def test_workflow_with_no_review_issues(self, mock_get, mock_run):
+        """Test workflow when no review issues are found."""
         # Setup clean PR
         pr_response = Mock()
         pr_response.json.return_value = {
@@ -337,6 +338,7 @@ index 8901234..5678901 100644
         # Claude finds no issues
         mock_run.side_effect = [
             Mock(returncode=0, stdout='claude version 1.0.0', stderr=''),
+            Mock(returncode=0, stdout='{"findings": [], "analysis_summary": {"review_completed": true}}', stderr=''),
             Mock(returncode=0, stdout='{"findings": [], "analysis_summary": {"review_completed": true}}', stderr='')
         ]
         
@@ -427,6 +429,7 @@ index 0000000..1234567
         # Claude handles it gracefully
         mock_run.side_effect = [
             Mock(returncode=0, stdout='claude version 1.0.0', stderr=''),
+            Mock(returncode=0, stdout='{"findings": []}', stderr=''),
             Mock(returncode=0, stdout='{"findings": []}', stderr='')
         ]
         
@@ -506,6 +509,7 @@ index 1234567..8901234 100644
         
         mock_run.side_effect = [
             Mock(returncode=0, stdout='claude version 1.0.0', stderr=''),
+            Mock(returncode=0, stdout='{"findings": []}', stderr=''),
             Mock(returncode=0, stdout='{"findings": []}', stderr='')
         ]
         

--- a/docs/custom-filtering-instructions.md
+++ b/docs/custom-filtering-instructions.md
@@ -1,10 +1,10 @@
 # Custom False Positive Filtering Instructions
 
-The Claude Code Security Reviewer Action supports custom false positive filtering instructions, allowing you to tailor the security analysis to your specific environment and requirements.
+The Claude Code Reviewer Action supports custom false positive filtering instructions, allowing you to tailor the review to your specific environment and requirements.
 
 ## Overview
 
-By default, the SAST action includes a comprehensive set of exclusions and criteria for filtering out false positives. However, every organization has unique security requirements, technology stacks, and threat models. The `false-positive-filtering-instructions` input allows you to provide your own custom criteria.
+By default, the review includes a comprehensive set of exclusions and criteria for filtering out low-signal findings. However, every organization has unique requirements, technology stacks, and risk tolerances. The `false-positive-filtering-instructions` input allows you to provide your own custom criteria.
 
 ## Usage
 
@@ -12,7 +12,7 @@ By default, the SAST action includes a comprehensive set of exclusions and crite
 2. Reference it in your workflow:
 
 ```yaml
-- uses: anthropics/claude-code-security-review@main
+- uses: PSPDFKit-labs/claude-code-review@main
   with:
     false-positive-filtering-instructions: .github/false-positive-filtering.txt
 ```
@@ -25,10 +25,10 @@ The file should contain plain text with three main sections:
 List patterns that should be automatically excluded from findings.
 
 ### 2. SIGNAL QUALITY CRITERIA
-Questions to assess whether a finding represents a real vulnerability.
+Questions to assess whether a finding represents a real, actionable issue.
 
 ### 3. PRECEDENTS
-Specific guidance for common security patterns in your environment.
+Specific guidance for common patterns in your environment.
 
 ## Example
 
@@ -41,14 +41,14 @@ If no custom file is provided, the action uses default instructions tuned to wor
 ## Best Practices
 
 1. **Start with defaults**: Begin with the default instructions and modify based on false positives you encounter
-2. **Be specific**: Include details about your security architecture (e.g., "We use AWS Cognito for all authentication")
-3. **Document assumptions**: Explain why certain patterns are excluded (e.g., "k8s resource limits prevent DOS")
+2. **Be specific**: Include details about your architecture and conventions
+3. **Document assumptions**: Explain why certain patterns are excluded
 4. **Version control**: Track changes to your filtering instructions alongside your code
-5. **Team review**: Have your security team review and approve the filtering instructions
+5. **Team review**: Have your reviewers agree on the filtering instructions
 
 ## Common Customizations
 
 - **Technology-specific exclusions**: Exclude findings that don't apply to your tech stack
-- **Infrastructure assumptions**: Document security controls at the infrastructure level
+- **Infrastructure assumptions**: Document controls at the infrastructure level
 - **Compliance requirements**: Adjust criteria based on your compliance needs
-- **Development practices**: Reflect your team's security practices and tooling
+- **Development practices**: Reflect your team's review standards

--- a/docs/custom-review-instructions.md
+++ b/docs/custom-review-instructions.md
@@ -1,0 +1,58 @@
+# Custom Code Review Instructions
+
+The Claude Code Reviewer Action supports custom code review instructions, allowing you to add organization-specific review priorities and standards.
+
+## Overview
+
+The default general review covers correctness, reliability, performance, maintainability, testing, and security. However, organizations often have specific requirements based on their:
+- Architecture and invariants
+- Performance or latency SLOs
+- Testing and release practices
+- Domain-specific constraints
+
+The `custom-review-instructions` input allows you to extend the general review focus beyond the defaults.
+
+## Usage
+
+1. Create a text file containing your custom review instructions (e.g., `.github/custom-review-instructions.txt`)
+2. Reference it in your workflow:
+
+```yaml
+- uses: PSPDFKit-labs/claude-code-review@main
+  with:
+    custom-review-instructions: .github/custom-review-instructions.txt
+```
+
+## File Format
+
+The file should contain additional review guidance in plain text. Consider using headings and bullet points to keep it clear. Aim for:
+- Specific requirements or invariants to protect
+- Known fragile areas to scrutinize
+- Performance/scale constraints to enforce
+- Testing expectations for high-risk changes
+
+### Example Structure:
+```
+**Architecture Invariants:**
+- All writes must be idempotent for retry safety
+- API responses must include correlation IDs
+
+**Performance Constraints:**
+- No new O(n^2) algorithms in request handlers
+- P95 latency must remain under 200ms
+
+**Testing Expectations:**
+- Add unit tests for all validation branches
+- Include integration tests for payment flows
+```
+
+## Best Practices
+
+1. **Be Concrete**: Focus on actionable rules and invariants
+2. **Keep It Short**: Favor a concise list over an exhaustive checklist
+3. **Avoid Duplicates**: Don’t restate the default categories unless you need emphasis
+4. **Review Regularly**: Update instructions as your architecture evolves
+
+## Example
+
+See [examples/custom-review-instructions.txt](../examples/custom-review-instructions.txt) for a ready-to-use template.

--- a/docs/custom-security-scan-instructions.md
+++ b/docs/custom-security-scan-instructions.md
@@ -1,10 +1,10 @@
 # Custom Security Scan Instructions
 
-The Claude Code Security Reviewer Action supports custom security scan instructions, allowing you to add organization-specific vulnerability categories to the security audit.
+The Claude Code Reviewer Action supports custom security scan instructions, allowing you to add organization-specific vulnerability categories to the security section of the review.
 
 ## Overview
 
-The default security scan covers common vulnerability categories like SQL injection, XSS, authentication issues, etc. However, organizations often have specific security concerns based on their:
+The default reviews cover correctness, reliability, performance, maintainability, testing, and security. The security sections include common vulnerability categories like SQL injection, XSS, and authentication issues. Organizations often have specific security concerns based on their:
 - Technology stack (GraphQL, gRPC, specific cloud providers)
 - Compliance requirements (GDPR, HIPAA, PCI DSS)
 - Industry-specific vulnerabilities (financial services, healthcare)
@@ -18,7 +18,7 @@ The `custom-security-scan-instructions` input allows you to extend the security 
 2. Reference it in your workflow:
 
 ```yaml
-- uses: anthropics/claude-code-security-review@main
+- uses: PSPDFKit-labs/claude-code-review@main
   with:
     custom-security-scan-instructions: .github/custom-security-categories.txt
 ```
@@ -45,16 +45,16 @@ The file should contain additional security categories in the same format as the
 ## Examples
 
 ### Industry-Specific Example
-See [examples/organization-specific-scan-instructions.txt](../examples/custom-security-scan-instructions.txt) for an example set of instructions that customize Claude Code to look for industry-specific security weaknesses including:
+See [examples/custom-security-scan-instructions.txt](../examples/custom-security-scan-instructions.txt) for an example set of instructions that customize Claude Code to look for industry-specific security weaknesses including:
 - Compliance checks (GDPR, HIPAA, PCI DSS)
 - Financial services security
 - E-commerce specific issues
 
 ## How It Works
 
-Your custom instructions are appended to the security audit prompt after the default "Data Exposure" category. This means:
-1. All default categories are still checked
-2. Your custom categories extend (not replace) the default scan
+Your custom instructions are appended to the security sections of both the general review and the dedicated security review prompts. This means:
+1. All default security categories are still checked
+2. Your custom categories extend (not replace) the default security scan
 3. The same HIGH/MEDIUM/LOW severity guidelines apply
 
 ## Best Practices
@@ -67,7 +67,7 @@ Your custom instructions are appended to the security audit prompt after the def
 
 ## Default Categories Reference
 
-The default scan already includes:
+The default security scan already includes:
 - Input Validation (SQL injection, command injection, XXE, etc.)
 - Authentication & Authorization
 - Crypto & Secrets Management

--- a/examples/custom-false-positive-filtering.txt
+++ b/examples/custom-false-positive-filtering.txt
@@ -1,33 +1,22 @@
 HARD EXCLUSIONS - Automatically exclude findings matching these patterns:
-1. All DOS/resource exhaustion - we have k8s resource limits and autoscaling
-2. Missing rate limiting - handled by our API gateway
-3. Tabnabbing vulnerabilities - acceptable risk per our threat model
-4. Test files (ending in _test.go, _test.js, or in __tests__ directories)
-5. Documentation files (*.md, *.rst)
-6. Configuration files that are not exposed to users (internal configs)
-7. Memory safety in Rust, Go, or managed languages
-8. GraphQL introspection queries - we intentionally expose schema in dev
-9. Missing CSRF protection - we use stateless JWT auth exclusively
-10. Timing attacks on non-cryptographic operations
-11. Regex DoS in input validation (we have request timeouts)
-12. Missing security headers in internal services (only public-facing services need them)
+1. Purely stylistic or formatting preferences (naming, spacing, comment wording)
+2. Documentation-only issues or typos without behavioral impact
+3. Refactor suggestions without a concrete bug, regression, or risk reduction
+4. Test-only changes that do not affect production behavior
+5. Hypothetical performance concerns without evidence in the diff
+6. Security-only concerns covered by existing gateway controls (documented below)
 
 SIGNAL QUALITY CRITERIA - For remaining findings, assess:
-1. Can an unauthenticated external attacker exploit this?
-2. Is there actual data exfiltration or system compromise potential?
-3. Is this exploitable in our production Kubernetes environment?
-4. Does this bypass our API gateway security controls?
+1. Is there a concrete failure mode or regression introduced by this PR?
+2. Is the impact meaningful (data loss, outage, auth bypass, incorrect results)?
+3. Is the issue reproducible from the diff and context?
+4. Would this be actionable for the team to fix?
 
-PRECEDENTS - 
-1. We use AWS Cognito for all authentication - auth bypass must defeat Cognito
-2. All APIs require valid JWT tokens validated at the gateway level
-3. SQL injection is only valid if using raw queries (we use Prisma ORM everywhere)
-4. All internal services communicate over mTLS within the k8s cluster
-5. Secrets are in AWS Secrets Manager or k8s secrets, never in code
-6. We allow verbose error messages in dev/staging (not production)
-7. File uploads go directly to S3 with presigned URLs (no local file handling)
-8. All user input is considered untrusted and validated on the backend
-9. Frontend validation is only for UX, not security
-10. We use CSP headers and strict Content-Type validation
-11. CORS is configured per-service based on actual needs
-12. All webhooks use HMAC signature verification
+PRECEDENTS -
+1. We use AWS Cognito for authentication; auth bypass must defeat Cognito
+2. All APIs require valid JWTs validated at the gateway level
+3. SQL injection is only valid if using raw queries (we use Prisma ORM)
+4. Frontend validation is only for UX; backend validates all inputs
+5. P95 latency must remain below 200ms for request handlers
+6. All write APIs must be idempotent for retry safety
+7. Secrets are in AWS Secrets Manager or k8s secrets, never in code

--- a/examples/custom-review-instructions.txt
+++ b/examples/custom-review-instructions.txt
@@ -1,0 +1,11 @@
+**Architecture Invariants:**
+- All write APIs must be idempotent (safe to retry)
+- Requests must carry a correlation ID through logs
+
+**Performance Constraints:**
+- Avoid O(n^2) operations in request handlers
+- Avoid synchronous network calls on the main request thread
+
+**Testing Expectations:**
+- Add unit tests for new validation branches
+- Add integration tests for payment flows and refunds

--- a/scripts/comment-pr-findings.bun.test.js
+++ b/scripts/comment-pr-findings.bun.test.js
@@ -249,7 +249,7 @@ describe('comment-pr-findings.js', () => {
 
       await import('./comment-pr-findings.js')
       expect(capturedReviewData).toBeDefined();
-      expect(capturedReviewData.comments[0].body).toContain('🤖 **Security Issue: Insecure pickle loads**');
+      expect(capturedReviewData.comments[0].body).toContain('🤖 **Code Review Finding: Insecure pickle loads**');
     });
 
     test('should generate correct yaml.load autofix', async () => {
@@ -305,7 +305,7 @@ describe('comment-pr-findings.js', () => {
 
       await import('./comment-pr-findings.js')
       expect(capturedReviewData).toBeDefined();
-      expect(capturedReviewData.comments[0].body).toContain('🤖 **Security Issue: Unsafe YAML deserialization**');
+      expect(capturedReviewData.comments[0].body).toContain('🤖 **Code Review Finding: Unsafe YAML deserialization**');
     });
 
     test('should preserve indentation in autofix', async () => {
@@ -361,7 +361,7 @@ describe('comment-pr-findings.js', () => {
 
       await import('./comment-pr-findings.js')
       expect(capturedReviewData).toBeDefined();
-      expect(capturedReviewData.comments[0].body).toContain('🤖 **Security Issue: Insecure pickle loads**');
+      expect(capturedReviewData.comments[0].body).toContain('🤖 **Code Review Finding: Insecure pickle loads**');
     });
   });
 
@@ -489,7 +489,7 @@ describe('comment-pr-findings.js', () => {
       expect(capturedReviewData.comments).toHaveLength(1);
       
       const comment = capturedReviewData.comments[0];
-      expect(comment.body).toContain('🤖 **Security Issue:');
+      expect(comment.body).toContain('🤖 **Code Review Finding:');
       expect(comment.body).toContain('**Severity:** HIGH');
       expect(comment.body).toContain('**Category:** security_issue');
       expect(comment.body).toContain('**Tool:** ClaudeCode AI Security Analysis');


### PR DESCRIPTION
## Overview
This PR generalizes the action into a dual‑pass reviewer: a broad code‑quality review plus a dedicated security pass. It also refreshes the slash commands, filtering logic, and docs to match the new workflow.

## What Changed
- Run two review passes in the GitHub Action: general review + security‑focused review
- Added inputs to toggle each pass (`run-general-review`, `run-security-review`)
- Introduced a security‑specific prompt alongside the general prompt
- Updated `.claude/commands/code-review.md` and `.claude/commands/security-review.md` to align with the new multi‑agent workflow
- Strengthened filtering logic and metadata to handle security vs general findings cleanly
- Updated documentation and examples to reference the PSPDFKit‑labs fork
- Added/updated tests for the dual‑pass flow

## Why
A single pass blends concerns and can dilute security‑specific signal. Running a dedicated security pass improves focus without losing broader quality review coverage.

## Testing
- `python -m pytest claudecode -v`