### PR TITLE
Update the haiku model used in validate_api_access since claude-3-5-haiku-20241022 is deprecated

### DIFF
--- a/claudecode/claude_api_client.py
+++ b/claudecode/claude_api_client.py
@@ -59,7 +59,7 @@ class ClaudeAPIClient:
         try:
             # Simple test call to verify API access
             self.client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model=self.model,
                 max_tokens=10,
                 messages=[{"role": "user", "content": "Hello"}],
                 timeout=10

--- a/claudecode/claude_api_client.py
+++ b/claudecode/claude_api_client.py
@@ -10,7 +10,7 @@ from anthropic import Anthropic
 
 from claudecode.constants import (
     DEFAULT_CLAUDE_MODEL, DEFAULT_TIMEOUT_SECONDS, DEFAULT_MAX_RETRIES,
-    RATE_LIMIT_BACKOFF_MAX, PROMPT_TOKEN_LIMIT,
+    RATE_LIMIT_BACKOFF_MAX, PROMPT_TOKEN_LIMIT, VALIDATION_MODEL,
 )
 from claudecode.json_parser import parse_json_with_fallbacks
 from claudecode.logger import get_logger
@@ -59,7 +59,7 @@ class ClaudeAPIClient:
         try:
             # Simple test call to verify API access
             self.client.messages.create(
-                model=self.model,
+                model=VALIDATION_MODEL,
                 max_tokens=10,
                 messages=[{"role": "user", "content": "Hello"}],
                 timeout=10

--- a/claudecode/constants.py
+++ b/claudecode/constants.py
@@ -6,6 +6,7 @@ import os
 
 # API Configuration
 DEFAULT_CLAUDE_MODEL = os.environ.get('CLAUDE_MODEL') or 'claude-opus-4-1-20250805'
+VALIDATION_MODEL = 'claude-haiku-4-5'
 DEFAULT_TIMEOUT_SECONDS = 180  # 3 minutes
 DEFAULT_MAX_RETRIES = 3
 RATE_LIMIT_BACKOFF_MAX = 30  # Maximum backoff time for rate limits

--- a/claudecode/test_claude_api_client.py
+++ b/claudecode/test_claude_api_client.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Pytest tests for Claude API client.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from claudecode.claude_api_client import ClaudeAPIClient
+
+
+class TestValidateApiAccess:
+    """Test validate_api_access uses self.model instead of a hardcoded value."""
+
+    def test_validate_api_access_uses_instance_model(self):
+        """Ensure validate_api_access passes self.model to the API call."""
+        custom_model = "claude-sonnet-4-20250514"
+        client = ClaudeAPIClient(model=custom_model, api_key="fake-key")
+
+        mock_response = MagicMock()
+        with patch.object(client.client.messages, "create", return_value=mock_response) as mock_create:
+            success, error = client.validate_api_access()
+
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["model"] == custom_model, (
+            f"Expected model '{custom_model}', got '{call_kwargs['model']}'"
+        )
+        assert success is True
+        assert error == ""
+
+    def test_validate_api_access_uses_default_model(self):
+        """Ensure validate_api_access uses DEFAULT_CLAUDE_MODEL when no model is specified."""
+        from claudecode.constants import DEFAULT_CLAUDE_MODEL
+
+        client = ClaudeAPIClient(api_key="fake-key")
+
+        mock_response = MagicMock()
+        with patch.object(client.client.messages, "create", return_value=mock_response) as mock_create:
+            success, _ = client.validate_api_access()
+
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["model"] == DEFAULT_CLAUDE_MODEL
+        assert success is True

--- a/claudecode/test_claude_api_client.py
+++ b/claudecode/test_claude_api_client.py
@@ -6,13 +6,14 @@ Pytest tests for Claude API client.
 from unittest.mock import patch, MagicMock
 
 from claudecode.claude_api_client import ClaudeAPIClient
+from claudecode.constants import VALIDATION_MODEL
 
 
 class TestValidateApiAccess:
-    """Test validate_api_access uses self.model instead of a hardcoded value."""
+    """Test validate_api_access uses VALIDATION_MODEL for cheap validation pings."""
 
-    def test_validate_api_access_uses_instance_model(self):
-        """Ensure validate_api_access passes self.model to the API call."""
+    def test_validate_api_access_uses_validation_model(self):
+        """Ensure validate_api_access uses VALIDATION_MODEL, not self.model."""
         custom_model = "claude-sonnet-4-20250514"
         client = ClaudeAPIClient(model=custom_model, api_key="fake-key")
 
@@ -22,22 +23,22 @@ class TestValidateApiAccess:
 
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args[1]
-        assert call_kwargs["model"] == custom_model, (
-            f"Expected model '{custom_model}', got '{call_kwargs['model']}'"
+        assert call_kwargs["model"] == VALIDATION_MODEL, (
+            f"Expected VALIDATION_MODEL '{VALIDATION_MODEL}', got '{call_kwargs['model']}'"
         )
         assert success is True
         assert error == ""
 
-    def test_validate_api_access_uses_default_model(self):
-        """Ensure validate_api_access uses DEFAULT_CLAUDE_MODEL when no model is specified."""
-        from claudecode.constants import DEFAULT_CLAUDE_MODEL
-
-        client = ClaudeAPIClient(api_key="fake-key")
+    def test_validate_api_access_does_not_use_instance_model(self):
+        """Ensure validate_api_access does not pass self.model (expensive) to the validation call."""
+        expensive_model = "claude-opus-4-1-20250805"
+        client = ClaudeAPIClient(model=expensive_model, api_key="fake-key")
 
         mock_response = MagicMock()
         with patch.object(client.client.messages, "create", return_value=mock_response) as mock_create:
             success, _ = client.validate_api_access()
 
         call_kwargs = mock_create.call_args[1]
-        assert call_kwargs["model"] == DEFAULT_CLAUDE_MODEL
+        assert call_kwargs["model"] == VALIDATION_MODEL
+        assert call_kwargs["model"] != expensive_model
         assert success is True


### PR DESCRIPTION
`validate_api_access()` hardcoded `claude-3-5-haiku-20241022` which is deprecated, causing all review actions to fail. The method intentionally uses a Haiku model (cheap/fast) for validation pings rather than the configured analysis model.

- Added `VALIDATION_MODEL` constant in `constants.py` set to `claude-haiku-4-5`
- Updated `validate_api_access()` to use `VALIDATION_MODEL` instead of the hardcoded deprecated string
- Updated tests to verify validation uses the dedicated constant, not `self.model`

```python
# Before — hardcoded deprecated model
self.client.messages.create(model="claude-3-5-haiku-20241022", ...)

# After — dedicated constant for validation pings
self.client.messages.create(model=VALIDATION_MODEL, ...)
```