### PR TITLE
Add security category coverage for SSRF

### DIFF
--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -53,6 +53,7 @@ SECURITY CATEGORIES TO EXAMINE:
 - Template injection in templating engines
 - NoSQL injection in database queries
 - Path traversal in file operations
+- SSRF via unvalidated/unsanitized user input that controls the host or protocol
 
 **Authentication & Authorization Issues:**
 - Authentication bypass logic

--- a/claudecode/prompts.py
+++ b/claudecode/prompts.py
@@ -72,6 +72,7 @@ SECURITY CATEGORIES TO EXAMINE:
 - Template injection in templating engines
 - NoSQL injection in database queries
 - Path traversal in file operations
+- SSRF via unvalidated/unsanitized user input that controls the host or protocol
 
 **Authentication & Authorization Issues:**
 - Authentication bypass logic


### PR DESCRIPTION
The project does not have any guiding prompts to cover SSRF issues that result from unvalidated/unsanitized user input that can control the host or protocol. 

There are [instructions that exclude SSRF](https://github.com/anthropics/claude-code-security-review/blob/0c6a49f1fa56a1d472575da86a94dbc1edb78eda/.claude/commands/security-review.md?plain=1#L151) but no prompting that calls out what types of SSRF to look for.
> `> 13. SSRF vulnerabilities that only control the path. SSRF is only a concern if it can control the host or protocol.`

**GitHub Issue**: https://github.com/anthropics/claude-code-security-review/issues/83