### PR TITLE
feat: add Dependency & Supply Chain Security audit category

### DIFF
--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -81,6 +81,15 @@ SECURITY CATEGORIES TO EXAMINE:
 - API endpoint data leakage
 - Debug information exposure
 
+**Dependency & Supply Chain Security:**
+- Known vulnerable dependencies (CVEs in pinned versions in manifest files)
+- Unpinned or loosely pinned dependency versions (e.g. `*`, `latest`, `>=` without upper bound)
+- Dependencies from untrusted or non-standard registries
+- Typosquatting risks in package names (e.g. misspelled popular packages)
+- Dependency confusion (private vs public namespace conflicts)
+- Malicious post-install scripts in dependency manifests
+- Lock file integrity issues (missing, inconsistent, or uncommitted lock files)
+
 Additional notes:
 - Even if something is only exploitable from the local network, it can still be a HIGH severity issue
 

--- a/claudecode/prompts.py
+++ b/claudecode/prompts.py
@@ -99,6 +99,15 @@ SECURITY CATEGORIES TO EXAMINE:
 - PII handling violations
 - API endpoint data leakage
 - Debug information exposure
+
+**Dependency & Supply Chain Security:**
+- Known vulnerable dependencies (CVEs in pinned versions in manifest files)
+- Unpinned or loosely pinned dependency versions (e.g. `*`, `latest`, `>=` without upper bound)
+- Dependencies from untrusted or non-standard registries
+- Typosquatting risks in package names (e.g. misspelled popular packages)
+- Dependency confusion (private vs public namespace conflicts)
+- Malicious post-install scripts in dependency manifests
+- Lock file integrity issues (missing, inconsistent, or uncommitted lock files)
 {custom_categories_section}
 Additional notes:
 - Even if something is only exploitable from the local network, it can still be a HIGH severity issue

--- a/claudecode/test_prompts.py
+++ b/claudecode/test_prompts.py
@@ -323,3 +323,52 @@ diff --git a/émojis.py b/émojis.py
         assert "émoji-user" in prompt
         assert "émojis.py" in prompt
         assert "🚨" in prompt  # From diff
+    def test_get_security_audit_prompt_contains_supply_chain_category(self):
+        """Test that the prompt includes the Dependency & Supply Chain Security category."""
+        pr_data = {
+            "number": 1,
+            "title": "Update dependencies",
+            "body": "Bumping versions",
+            "user": "bot",
+            "changed_files": 1,
+            "additions": 1,
+            "deletions": 1,
+            "head": {"repo": {"full_name": "owner/repo"}},
+            "files": [{"filename": "package.json", "status": "modified",
+                        "additions": 1, "deletions": 1}]
+        }
+
+        prompt = get_security_audit_prompt(pr_data)
+
+        assert "Dependency & Supply Chain Security" in prompt
+        assert "typosquatting" in prompt.lower()
+        assert "dependency confusion" in prompt.lower()
+        assert "lock file" in prompt.lower()
+        assert "post-install scripts" in prompt.lower()
+
+    def test_get_security_audit_prompt_supply_chain_with_custom_instructions(self):
+        """Test that custom_scan_instructions still injects after the supply chain category."""
+        pr_data = {
+            "number": 2,
+            "title": "Test",
+            "body": "",
+            "user": "tester",
+            "changed_files": 1,
+            "additions": 1,
+            "deletions": 1,
+            "head": {"repo": {"full_name": "owner/repo"}},
+            "files": [{"filename": "setup.py", "status": "modified",
+                        "additions": 1, "deletions": 1}]
+        }
+
+        custom = "Also check for GPL license violations."
+        prompt = get_security_audit_prompt(pr_data, custom_scan_instructions=custom)
+
+        supply_chain_pos = prompt.find("Dependency & Supply Chain Security")
+        custom_pos = prompt.find(custom)
+
+        assert supply_chain_pos != -1, "Supply chain section missing"
+        assert custom_pos != -1, "Custom instructions missing"
+        assert supply_chain_pos < custom_pos, (
+            "Custom instructions appeared before the supply chain section"
+        )


### PR DESCRIPTION
## Summary

Adds a missing security category to both the Claude audit prompt and the slash command template. Current scans cover injection, auth, crypto, etc. but have no supply chain coverage despite it being a top attack vector (SolarWinds, XZ utils, npm typosquatting incidents).

The new **Dependency & Supply Chain Security** category checks for:
- Known vulnerable dependencies (CVEs in pinned versions in manifest files)
- Unpinned or loosely pinned dependency versions (e.g. `*`, `latest`, `>=` without upper bound)
- Dependencies from untrusted or non-standard registries
- Typosquatting risks in package names (e.g. misspelled popular packages)
- Dependency confusion (private vs public namespace conflicts)
- Malicious post-install scripts in dependency manifests
- Lock file integrity issues (missing, inconsistent, or uncommitted lock files)

Both `claudecode/prompts.py` and `.claude/commands/security-review.md` are updated to stay in sync.

## Test plan
- [ ] `test_get_security_audit_prompt_contains_supply_chain_category` — verifies the category is present in generated prompts
- [ ] `test_get_security_audit_prompt_supply_chain_with_custom_instructions` — verifies custom instructions still inject correctly after the new section

Closes #31